### PR TITLE
add missing rpm macros on CentOS Stream 9 - otherwise building fails

### DIFF
--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 MAINTAINER Sergey Nartimov <just.lest@gmail.com>
 
 RUN dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb
-RUN yum install -y yum-utils rpm-build rpm-sign redhat-rpm-config rpmdevtools createrepo && \
+RUN yum install -y yum-utils rpm-build rpm-sign redhat-rpm-config rpmdevtools createrepo systemd-rpm-macros && \
   yum clean all
 RUN echo '%_topdir /rpmbuild' > /root/.rpmmacros
 


### PR DESCRIPTION
Some how the systemd macros are not pulled in anymore automatically and thus need to present explicitly. 