### PR TITLE
Update for EL10

### DIFF
--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,0 +1,10 @@
+FROM almalinux:10
+MAINTAINER Sergey Nartimov <just.lest@gmail.com>
+
+RUN dnf install -y yum-utils rpm-build rpm-sign redhat-rpm-config rpmdevtools createrepo systemd-rpm-macros && \
+  dnf clean all
+RUN echo '%_topdir /rpmbuild' > /root/.rpmmacros
+
+WORKDIR /rpmbuild
+
+ADD bin/build-spec /usr/local/bin/build-spec

--- a/Dockerfile.stream10
+++ b/Dockerfile.stream10
@@ -1,0 +1,11 @@
+FROM quay.io/centos/centos:stream10
+MAINTAINER Sergey Nartimov <just.lest@gmail.com>
+
+RUN dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb
+RUN yum install -y yum-utils rpm-build rpm-sign redhat-rpm-config rpmdevtools createrepo systemd-rpm-macros && \
+  yum clean all
+RUN echo '%_topdir /rpmbuild' > /root/.rpmmacros
+
+WORKDIR /rpmbuild
+
+ADD bin/build-spec /usr/local/bin/build-spec

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+build10:
+	docker build --pull --force-rm \
+		-f Dockerfile.alma10 \
+		-t lest/centos-rpm-builder:alma10 \
+		.
 build9:
 	docker build --pull --force-rm \
 		-f Dockerfile.stream9 \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build10:
 	docker build --pull --force-rm \
-		-f Dockerfile.alma10 \
-		-t lest/centos-rpm-builder:alma10 \
+		-f Dockerfile.stream10 \
+		-t lest/centos-rpm-builder:stream10 \
 		.
 build9:
 	docker build --pull --force-rm \


### PR DESCRIPTION
CentOS Stream 10 has been available for a while now. For a non-Stream distro, AlmaLinux10 has updated stuff on Dockerhub before Oracle or Rocky, so using Alma.